### PR TITLE
Left wings are being left out of lineup gewneration in Draftkings.

### DIFF
--- a/R/draftkings-nhl.r
+++ b/R/draftkings-nhl.r
@@ -29,7 +29,7 @@ add_dk_nhl_roster_positions_constraint <- function(model, nhl) {
   }
 
   Ctr <- is_position("C")
-  LW <- is_position("W")
+  LW <- is_position("LW")
   RW <- is_position("RW")
   D <- is_position("D")
   G <- is_position("G")


### PR DESCRIPTION
Only right wings are included when creating lineups for Draftkings NHL. This pull request insures left wings are included as well.